### PR TITLE
Extend the Mock API capabilities

### DIFF
--- a/src/mmc/loaders/mlfcliploader.py
+++ b/src/mmc/loaders/mlfcliploader.py
@@ -50,6 +50,7 @@ class MlfClipLoader(BaseMmcLoader):
 
         model.requires_grad_(False)
         model.eval()
+        model.set_grad_checkpointing()
         model.to(device, memory_format=torch.channels_last)
         #tokenizer = clip.tokenize # clip.simple_tokenizer.SimpleTokenizer()
         tokenizer = open_clip.tokenize # clip.simple_tokenizer.SimpleTokenizer()

--- a/src/mmc/mock/openai.py
+++ b/src/mmc/mock/openai.py
@@ -73,3 +73,9 @@ class MockOpenaiClip:
         # bypass pre-processor
         project = self.mmc_object.modes['text']['projector']
         return project(text)
+    
+    def tokenize(self):
+        return self.mmc_object.modes['text']['preprocessor']
+    
+    def normalize(self):
+        return self.mmc_object.modes['image']['preprocessor']

--- a/src/mmc/mock/openai.py
+++ b/src/mmc/mock/openai.py
@@ -74,8 +74,8 @@ class MockOpenaiClip:
         project = self.mmc_object.modes['text']['projector']
         return project(text)
     
-    def tokenize(self):
+    def preprocess_text(self):
         return self.mmc_object.modes['text']['preprocessor']
     
-    def normalize(self):
+    def preprocess_image(self):
         return self.mmc_object.modes['image']['preprocessor']


### PR DESCRIPTION
This was useful to do for integrating MMC with Princess Generator. I know this makes the Mock API go beyond its scope, but: 
1. OpenAI's CLIP has this "tokenize" function. As we can't do it on the library level, as the tokenizer is different for every model - I think adding an option in the model itself might make sense
2. We gotta think how much heavy lifting we want to do for the devs. From my perspective I think default operations such as tokenization, preprocessing, normalization should be abstracted to them 

That said not sure if the way I did it here is the best to go about it - almost sure it's not