### PR TITLE
Wrapper class for mocking the openai CLIP.clip module

### DIFF
--- a/src/mmc/mock/openai.py
+++ b/src/mmc/mock/openai.py
@@ -9,6 +9,39 @@ DEVICE = torch.device('cuda') if torch.cuda.is_available() else torch.device('cp
 
 from loguru import logger
 
+
+class MockOpenaiClipModule:
+    """
+    Mocks the OpenAI CLIP.clip module API
+    """
+    def __init__(self, loader, device=DEVICE):
+        self._loader = loader
+        self.device = device
+
+    def available_models(self):
+        # ...should this return the mmc registry?
+        return str(self._loader)
+
+    @property
+    def _model(self):
+        if not hasattr(self, '_model_'):
+            self._model_ = self._loader.load(self.device)
+        return self._model_
+
+    @property
+    def tokenize(self):
+        return self._model.modes['text']['preprocessor']
+
+    @property
+    def preprocess_image(self):
+        return self._model.modes['image']['preprocessor']
+
+    @property
+    def load(self, id, device=DEVICE):
+        clip = MockOpenaiClip(self._model, self.device)
+        return clip, self.preprocess_image
+
+
 @dataclass
 class MockVisionModel:
     input_resolution: int = 224

--- a/tests/test_module_mock.py
+++ b/tests/test_module_mock.py
@@ -1,0 +1,53 @@
+import pytest
+from loguru import logger
+import mmc
+import PIL
+import torch
+
+
+def test_init():
+    from mmc.mock.openai import MockOpenaiClipModule
+    from mmc.loaders import OpenAiClipLoader
+
+    ldr = OpenAiClipLoader(id='RN50')
+    clip = MockOpenaiClipModule(ldr)
+
+def test_available_models():
+    from mmc.mock.openai import MockOpenaiClipModule
+    from mmc.loaders import OpenAiClipLoader
+
+    ldr = OpenAiClipLoader(id='RN50')
+    clip = MockOpenaiClipModule(ldr)
+    assert clip.available_models() == str(ldr)
+
+def test_private_mmc():
+    from mmc.mock.openai import MockOpenaiClipModule, MockOpenaiClip
+    from mmc.loaders import OpenAiClipLoader
+    from mmc.multimodalcomparator import MultiModalComparator
+
+    ldr = OpenAiClipLoader(id='RN50')
+    clip = MockOpenaiClipModule(ldr)
+    #assert isinstance(clip._clip, MockOpenaiClip)
+    assert isinstance(clip._model, MultiModalComparator)
+
+
+def test_tokenize():
+    from mmc.mock.openai import MockOpenaiClipModule
+    from mmc.loaders import OpenAiClipLoader
+    from clip import tokenize
+
+    ldr = OpenAiClipLoader(id='RN50')
+    clip = MockOpenaiClipModule(ldr)
+    
+    test_text = "foo bar baz"
+    tokens = clip.tokenize(test_text)
+    assert isinstance(tokens, torch.Tensor)
+    assert tokens.shape[1] == tokenize(test_text).shape[1] 
+
+def test_preprocess_image():
+    pass
+
+def test_load():
+    pass
+
+


### PR DESCRIPTION
facilitates importing preprocessing facilities separately from the model, following the openai clip idiom